### PR TITLE
Modernize tooling and fix pandas deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Output file is optimized for the workflow above.
 > bash setup.sh
 ....
 
-> source env/bin/activate
+> source .venv/bin/activate
 
-> python3 aws-cost-and-usage-report.py -h
+> uv run aws-cost-and-usage-report.py -h
 usage: aws-cost-and-usage-report.py [-h] [--sensetivity SENSETIVITY] [--out OUT] [--debug]
 
 Generate cost and usage report for the last 3 month grouped by service

--- a/aws-cost-and-usage-report.py
+++ b/aws-cost-and-usage-report.py
@@ -115,7 +115,7 @@ def ce_response_to_dataframe(input):
     for column in df.columns:
         row_with_total.append(df[column].sum())
     row_wiht_total_series = pandas.Series(row_with_total, index = df.columns, name='Total Cost')
-    df = df.append(row_wiht_total_series)
+    df = pandas.concat([df, row_wiht_total_series.to_frame().T])
 
     # Sort data frame
     df.sort_values(by=df.columns[-1], ascending=False, inplace=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ boto3==1.26.155
 boto3-stubs[ce]==1.26.155
 flake8==3.9.2
 pylint==2.9.6
-pandas==1.5.3
+pandas==2.2.0
 numpy==1.26.4
 xlsxwriter==1.4.5

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 [ -d env ] && rm -rf env
+[ -d .venv ] && rm -rf .venv
 
-python3 -m venv env
-source env/bin/activate
-pip install -r requirements.txt
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements.txt


### PR DESCRIPTION
## Summary
This PR modernizes the project's Python tooling by migrating from traditional `venv` to `uv` for faster dependency management, and fixes pandas deprecation warnings for compatibility with pandas 2.x.

## Changes
- Migrate from `venv` to `uv` for package management
- Fix `pandas.append()` deprecation → use `pandas.concat()`  
- Update pandas from 1.5.3 to 2.2.0
- Update README with `uv run` commands
- Make setup.sh executable and use uv commands

## Motivation
- `uv` provides significantly faster package installation
- `pandas.append()` is deprecated since pandas 1.4.0 and removed in 2.0
- Ensures compatibility with modern pandas versions
- It doesn't work on my machine anymore

## Testing
- [ ] setup.sh runs successfully with uv
- [ ] Script executes without deprecation warnings
- [ ] Cost report generation works as expected